### PR TITLE
Remove Component Parameter options from top level parent component.

### DIFF
--- a/BlazorCylinderHead/Pages/Accordion.razor
+++ b/BlazorCylinderHead/Pages/Accordion.razor
@@ -4,25 +4,49 @@
 <h3>Accordion</h3>
 <hr/>
 <SPAccordion>
-    <SPCollapse Visible = "@collapse0Visible">
-        <SPCollapseHeader>
-            <SPHeading Size="HeadingSize.h5">
-                <SPButton Clicked="@(()=> collapse0Visible = !collapse0Visible)">
-                    Item 0 Heading
-                </SPButton>
-            </SPHeading>
-        </SPCollapseHeader>
+    <SPCollapse 
+        HeaderContents="This is my Header "
+        Size="HeadingSize.h3">
         <SPCollapseBody>
-            This is the visible content 
-            is the visible content
-            the visible content
-            visible content
-            contents.
-            
+            This content will show up when you click.
         </SPCollapseBody>
     </SPCollapse>
 </SPAccordion>
-
+<SPAccordion>
+    <SPCollapse
+        HeaderContents="This is my other Header"
+        Size="HeadingSize.h3">
+        <SPCollapseBody>
+            This is more contents that will show 
+        </SPCollapseBody>
+    </SPCollapse>
+</SPAccordion>
+<SPAccordion>
+    <SPCollapse
+        HeaderContents="Multi-level Accordion"
+        Size = "HeadingSize.h3">
+        <SPCollapseBody>
+            <SPAccordion>
+                <SPCollapse
+                    HeaderContents="Sub Level Item A "
+                    Size = "HeadingSize.h5">
+                    <SPCollapseBody>
+                        Here is my contents
+                    </SPCollapseBody>
+                </SPCollapse>
+            </SPAccordion>
+            <SPAccordion>
+                <SPCollapse
+                    HeaderContents="Sub Level Item B "
+                    Size = "HeadingSize.h5">
+                    <SPCollapseBody>
+                        Here is my contents
+                    </SPCollapseBody>
+                </SPCollapse>
+            </SPAccordion>
+        </SPCollapseBody>
+    </SPCollapse>
+</SPAccordion>
 @code {
-    bool collapse0Visible = false;
+    
 }

--- a/SparkPlug-Accordion/SPCollapse.razor
+++ b/SparkPlug-Accordion/SPCollapse.razor
@@ -1,25 +1,39 @@
 ﻿<div class="row align-center accordCollapse @Visibility">
     <CascadingValue Value="@Visible">
-        @SPCollapseHeader
+        <SPCollapseHeader> 
+            <SPHeading Size=@Size>
+                <SPButton Clicked="UpdateVisible">
+                    @HeaderContents
+                </SPButton>
+            </SPHeading>
+        </SPCollapseHeader>
     </CascadingValue>
 </div>
 <div class="row">
-    @if(Visible)
-        @SPCollapseBody
+    @if (Visible)
+        @ChildContent
 </div>
 
 @code {
     [Parameter]
-    public RenderFragment SPCollapseHeader { get; set; }
+    public string HeaderContents { get; set; }
     [Parameter]
-    public RenderFragment SPCollapseBody { get; set; }
+    public HeadingSize Size { get; set; }
     [Parameter]
+    public RenderFragment ChildContent { get; set; }
+
     public bool Visible { get; set; }
 
     protected string Visibility { get; set; }
 
-    protected override void OnParametersSet()
+    protected override void OnInitialized()
     {
+        Visible = false;
+    }
+    public void UpdateVisible()
+    {
+        Visible = !Visible;
         Visibility = Visible ? "accordCollapseVisible" : "accordCollapseHidden";
     }
+
 }


### PR DESCRIPTION
Visible parameter defined to close accordions when initialized. 
Top level component takes only 3 parameters Header, HeadingSize, and a SPCollapse body. 